### PR TITLE
Increases memory for build

### DIFF
--- a/.sbtopts
+++ b/.sbtopts
@@ -1,0 +1,4 @@
+-J-Xms2048m
+-J-Xmx2048m
+-J-XX:ReservedCodeCacheSize=256m
+-J-XX:MaxMetaspaceSize=512m


### PR DESCRIPTION
Releases were failing due to insufficient meta memory.